### PR TITLE
Modal improvements

### DIFF
--- a/cure/Views/Home/Index.cshtml
+++ b/cure/Views/Home/Index.cshtml
@@ -80,20 +80,24 @@
 
 @if (!ViewBag.AgeGateCookieAccepted)
 {
-    <div id="AgeGateModal" class="modal">
-        <div class="modal-content">
-            <p>This site is intended only for persons 18 years of age or older.</p>
-            <p>This site features content related to consensual adult sexuality. We do not condone or support abuse - in any form.</p>
-            <p>By using this site you affirm that you are of age and the viewing of sexually explicit material is legal in your country, state, or city. </p>
-            <form method="post" asp-area="" asp-controller="Home" asp-action="Index">
-                <div class="form-group">
-                    <input asp-for="Consent" type="checkbox" />
-                    <label asp-for="Consent">Check here if you consent.</label>
+    <div id="AgeGateModal" class="modal d-flex align-items-center" aria-modal="true" role="dialog">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-body">
+                    <p>This site is intended only for persons 18 years of age or older.</p>
+                    <p>This site features content related to consensual adult sexuality. We do not condone or support abuse - in any form.</p>
+                    <p>By using this site you affirm that you are of age and the viewing of sexually explicit material is legal in your country, state, or city. </p>
+                    <form method="post" asp-area="" asp-controller="Home" asp-action="Index">
+                        <div class="form-group">
+                            <input asp-for="Consent" type="checkbox" />
+                            <label asp-for="Consent">Check here if you consent.</label>
+                        </div>
+                        <div class="form-grou">
+                            <button class="flat-btn" type="submit" value="Accept">Accept</button>
+                        </div>
+                    </form>
                 </div>
-                <div class="form-grou">
-                    <button class="flat-btn" type="submit" value="Accept">Accept</button>
-                </div>
-            </form>
+            </div>
         </div>
     </div>
 }

--- a/cure/wwwroot/css/site.css
+++ b/cure/wwwroot/css/site.css
@@ -158,20 +158,15 @@ button.accept-policy {
 }
 
 .modal {
-    display: block;
-    position: fixed;
-    top: 30%;
-    left: 50%;
-    transform: translate(-50%, -10%);
+    background: rgba(0, 0, 0, 0.8);
+}
+  
+.modal-dialog {
     border: solid;
-    height: 30%;
-    width: 80%;
     background-color: black;
 }
 
 .modal-content {
-    width: auto;
-    height: auto;
     background-color: black;
     color: antiquewhite;
     text-align: center;

--- a/kicweb/Views/Admin/VendorIndex.cshtml
+++ b/kicweb/Views/Admin/VendorIndex.cshtml
@@ -59,9 +59,11 @@
 
 @if (ViewBag.Error is not null)
 {
-    <div id="ValidationErrorModal" class="modal">
-        <div class="modal-content">
-            <p>@ViewBag.Error</p>
+    <div id="ValidationErrorModal" class="modal d-flex align-items-center" aria-modal="true" role="dialog">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <p>@ViewBag.Error</p>
+            </div>
         </div>
     </div>
 }

--- a/kicweb/Views/Gen/Contact.cshtml
+++ b/kicweb/Views/Gen/Contact.cshtml
@@ -43,9 +43,11 @@
 
 @if (ViewBag.Error is not null)
 {
-    <div id="ValidationErrorModal" class="modal">
-        <div class="modal-content">
-            <p>There was a validation error, please try again.</p>
+    <div id="ValidationErrorModal" class="modal d-flex align-items-center" aria-modal="true" role="dialog">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <p>There was a validation error, please try again.</p>
+            </div>
         </div>
     </div>
 }

--- a/kicweb/Views/Gen/Presenters.cshtml
+++ b/kicweb/Views/Gen/Presenters.cshtml
@@ -65,9 +65,11 @@
 
 @if (ViewBag.Error is not null)
 {
-    <div id="ValidationErrorModal" class="modal">
-        <div class="modal-content">
-            <p>There was a validation error, please try again.</p>
+    <div id="ValidationErrorModal" class="modal d-flex align-items-center" aria-modal="true" role="dialog">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <p>There was a validation error, please try again.</p>
+            </div>
         </div>
     </div>
 }

--- a/kicweb/Views/Gen/Vendors.cshtml
+++ b/kicweb/Views/Gen/Vendors.cshtml
@@ -50,9 +50,11 @@
 
 @if (ViewBag.Error is not null)
 {
-    <div id="ValidationErrorModal" class="modal">
-        <div class="modal-content">
-            <p>There was a validation error, please try again.</p>
+    <div id="ValidationErrorModal" class="modal d-flex align-items-center" aria-modal="true" role="dialog">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <p>There was a validation error, please try again.</p>
+            </div>
         </div>
     </div>
 }

--- a/kicweb/Views/Gen/Volunteers.cshtml
+++ b/kicweb/Views/Gen/Volunteers.cshtml
@@ -86,11 +86,13 @@
     </div>
 </div>
 
-@if(ViewBag.Error is not null)
+@if (ViewBag.Error is not null)
 {
-    <div id="ValidationErrorModal" class="modal">
-        <div class="modal-content">
-            <p>There was a validation error, please try again.</p>
+    <div id="ValidationErrorModal" class="modal d-flex align-items-center" aria-modal="true" role="dialog">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <p>There was a validation error, please try again.</p>
+            </div>
         </div>
     </div>
 }

--- a/kicweb/Views/Home/Index.cshtml
+++ b/kicweb/Views/Home/Index.cshtml
@@ -91,20 +91,24 @@
 
 @if(!ViewBag.AgeGateCookieAccepted)
 {
-    <div id="AgeGateModal" class="modal">
-        <div class="modal-content">
-            <p>This site is intended only for persons 18 years of age or older.</p>
-            <p>This site features content related to consensual adult sexuality. We do not condone or support abuse - in any form.</p>
-            <p>By using this site you affirm that you are of age and the viewing of sexually explicit material is legal in your country, state, or city. </p>
-            <form method="post" asp-area="" asp-controller="Home" asp-action="Index">
-                <div class="form-group">
-                    <input asp-for="Consent" type="checkbox" />
-                    <label asp-for="Consent">Check here if you consent.</label>
+    <div id="AgeGateModal" class="modal d-flex align-items-center" aria-modal="true" role="dialog">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-body">
+                    <p>This site is intended only for persons 18 years of age or older.</p>
+                    <p>This site features content related to consensual adult sexuality. We do not condone or support abuse - in any form.</p>
+                    <p>By using this site you affirm that you are of age and the viewing of sexually explicit material is legal in your country, state, or city. </p>
+                    <form method="post" asp-area="" asp-controller="Home" asp-action="Index">
+                        <div class="form-group">
+                            <input asp-for="Consent" type="checkbox" />
+                            <label asp-for="Consent">Check here if you consent.</label>
+                        </div>
+                        <div class="form-grou">
+                            <button class="flat-btn" type="submit" value="Accept">Accept</button>
+                        </div>
+                    </form>
                 </div>
-                <div class="form-grou">
-                    <button class="flat-btn" type="submit" value="Accept">Accept</button>
-                </div>
-            </form>
+            </div>
         </div>
     </div>
 }

--- a/kicweb/wwwroot/css/site.css
+++ b/kicweb/wwwroot/css/site.css
@@ -179,23 +179,18 @@ button.accept-policy
     white-space: normal;
 }
 
-.modal
+.modal {
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.modal-dialog
 {
-    display: block;
-    position: fixed;
-    top: 30%;
-    left: 50%;
-    transform: translate(-50%, -10%);
     border: solid;
-    height: 30%;
-    width: 80%;
     background-color: black;
 }
 
 .modal-content
 {
-    width:auto;
-    height:auto;
     background-color:black;
     color:antiquewhite;
     text-align: center;


### PR DESCRIPTION
### **Description**

This updates the modals in `kicweb` and `cure` to use bootstrap's classes more effectively, which allows us to remove some of the custom CSS we're applying in site.css. This is why this is adding the `modal-dialog` and `modal-body` divs to each modal.

It also uses some bootstrap utility classes like [d-flex](https://getbootstrap.com/docs/5.3/utilities/flex/#enable-flex-behaviors) and [align-items-center](https://getbootstrap.com/docs/5.3/utilities/flex/#align-items), which is centering the modal for us.

By doing this, we get a nice backdrop on the modal now and better positioning at different screen sizes.

### **Screenshots**

Before/After (Mobile):

_This is how it's displayed on an iPhone SE. Notice the bottom portion gets cut off and you have to know to scroll to accept_
![image](https://github.com/user-attachments/assets/12f269e2-2f92-406e-813d-e1e501743277)

_This is how it will now display on an iPhone SE._
![image](https://github.com/user-attachments/assets/1f009263-e7fb-47ce-ab27-7e92a15d4131)



Before/After (Desktop):

![image](https://github.com/user-attachments/assets/7a063da9-70ac-41e8-9777-02e01dfb2b11)

![image](https://github.com/user-attachments/assets/60b55c9f-e994-44f3-8584-9a681a7f5691)


